### PR TITLE
Support for dimmers and optimizations

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -39,7 +39,7 @@ If you are running a pilight daemon on the same machine, you will probably skip 
 
 The optional setting `sharedWS = true` will share a single connection for devices addressing the same pilight instance.
 
-The Setting `type = "type"` can be "Switch" or "TemperatureSensor".
+The Setting `type = "type"` can be "Switch", "TemperatureSensor" or "Dimmer".
 
 Additionally you have the Homebridge options `accessory` (for the actual plugin) and `name` (for representation later).
 

--- a/index.js
+++ b/index.js
@@ -235,15 +235,6 @@ module.exports = function (homebridge) {
           this.services.push(dimmerService);
           break;
 
-        case 'Lamp':
-          let lampService = new homebridge.hap.Service.Lightbulb(this.config.name);
-          lampService
-            .getCharacteristic(homebridge.hap.Characteristic.On)
-            .on('get', this.getPowerState.bind(this))
-            .on('set', this.setPowerState.bind(this));
-          this.services.push(lampService);
-          break;
-
         case 'TemperatureSensor':
           let temperatureSensorService = new homebridge.hap.Service.TemperatureSensor(this.config.name);
           temperatureSensorService

--- a/index.js
+++ b/index.js
@@ -95,37 +95,37 @@ module.exports = function (homebridge) {
         }
       }
 
-      if (item == null) {
+      if (item === null) {
         return;
       }
 
       let service = this.getServiceForDevice(this.config.name);
 
-      if (item.values.state != undefined && service.testCharacteristic(homebridge.hap.Characteristic.On)) {
+      if (item.values.state !== undefined && service.testCharacteristic(homebridge.hap.Characteristic.On)) {
         this.deviceState = item.values.state === 'on';
         this.log(`Updated internal state to "${item.values.state}"`);
 
-        if (this.stateCallback != null) {
+        if (this.stateCallback !== null) {
           this.stateCallback(null);
           this.stateCallback = null;
         }
       }
 
-      if (item.values.dimlevel != undefined && service.testCharacteristic(homebridge.hap.Characteristic.Brightness)) {
+      if (item.values.dimlevel !== undefined && service.testCharacteristic(homebridge.hap.Characteristic.Brightness)) {
         this.dimLevel = item.values.dimlevel;
         this.log(`Updated internal dim level to ${item.values.dimlevel}`);
 
-        if (this.dimLevelCallback != null) {
+        if (this.dimLevelCallback !== null) {
           this.dimLevelCallback(null);
           this.dimLevelCallback = null;
         }
       }
 
-      if (item.values.temperature != undefined && service.testCharacteristic(homebridge.hap.Characteristic.CurrentTemperature)) {
+      if (item.values.temperature !== undefined && service.testCharacteristic(homebridge.hap.Characteristic.CurrentTemperature)) {
         this.deviceState = item.values.temperature;
         this.log(`Updated internal temperature to ${item.values.temperature}`);
       }
-   }
+    }
 
     getServiceForDevice(device) {
       return this.services.find(function (device, service) {
@@ -138,7 +138,7 @@ module.exports = function (homebridge) {
         this.log(`No dim level found`);
         callback(new Error('Not found'));
       } else {
-        const brightness = utils.dimlevelToBrightness(this.dimLevel)
+        const brightness = utils.dimlevelToBrightness(this.dimLevel);
         this.log(`Current dim level ${this.dimLevel} with brightness ${brightness}%`);
         callback(null, brightness);
       }
@@ -157,7 +157,7 @@ module.exports = function (homebridge) {
         return;        
       }
 
-      if (typeof(brightness) == "number") {
+      if (typeof(brightness) === "number") {
         dimlevel = utils.brightnessToDimlevel(brightness);
       }
       

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ module.exports = function (homebridge) {
 
       connection.emitter.on('connection::create', () => {
         // initial request all available values
-        this.log(`Requesting initial states...`);
+        this.log('Requesting initial states...');
         connection.send({action : 'request values'});
       });
 
@@ -108,6 +108,10 @@ module.exports = function (homebridge) {
         if (this.stateCallback !== null) {
           this.stateCallback(null);
           this.stateCallback = null;
+        } else {
+          service
+            .getCharacteristic(homebridge.hap.Characteristic.On)
+            .setValue(this.deviceState);
         }
       }
 
@@ -118,12 +122,20 @@ module.exports = function (homebridge) {
         if (this.dimLevelCallback !== null) {
           this.dimLevelCallback(null);
           this.dimLevelCallback = null;
+        } else {
+          service
+            .getCharacteristic(homebridge.hap.Characteristic.Brightness)
+            .setValue(utils.dimlevelToBrightness(this.dimLevel));
         }
       }
 
       if (item.values.temperature !== undefined && service.testCharacteristic(homebridge.hap.Characteristic.CurrentTemperature)) {
         this.deviceState = item.values.temperature;
         this.log(`Updated internal temperature to ${item.values.temperature}`);
+
+        service
+          .getCharacteristic(homebridge.hap.Characteristic.CurrentTemperature)
+          .setValue(this.deviceState);
       }
     }
 
@@ -135,7 +147,7 @@ module.exports = function (homebridge) {
     
     getDimLevel(callback) {
       if (this.dimLevel === undefined) {
-        this.log(`No dim level found`);
+        this.log('No dim level found');
         callback(new Error('Not found'));
       } else {
         const brightness = utils.dimlevelToBrightness(this.dimLevel);
@@ -157,7 +169,7 @@ module.exports = function (homebridge) {
         return;        
       }
 
-      if (typeof(brightness) === "number") {
+      if (typeof(brightness) === 'number') {
         dimlevel = utils.brightnessToDimlevel(brightness);
       }
       
@@ -174,7 +186,7 @@ module.exports = function (homebridge) {
     
     getPowerState(callback) {
       if (this.deviceState === undefined) {
-        this.log(`No power state found`);
+        this.log('No power state found');
         callback(new Error('Not found'));
       } else {
         callback(null, this.deviceState);
@@ -200,7 +212,7 @@ module.exports = function (homebridge) {
 
     getTemperature(callback) {
       if (this.deviceState === undefined) {
-        this.log(`No temperature found`);
+        this.log('No temperature found');
         callback(new Error('Not found'));
       } else {
         callback(null, this.deviceState);

--- a/index.js
+++ b/index.js
@@ -122,7 +122,8 @@ module.exports = function (homebridge) {
         if (this.dimLevelCallback !== null) {
           this.dimLevelCallback(null);
           this.dimLevelCallback = null;
-        } else {
+        } else if (this.deviceState !== undefined && this.deviceState === true) {
+          // Only set the dim level if the device is on
           service
             .getCharacteristic(homebridge.hap.Characteristic.Brightness)
             .setValue(utils.dimlevelToBrightness(this.dimLevel));
@@ -146,9 +147,12 @@ module.exports = function (homebridge) {
     }
     
     getDimLevel(callback) {
-      if (this.dimLevel === undefined) {
+      if (this.deviceState === undefined || this.dimLevel === undefined) {
         this.log('No dim level found');
         callback(new Error('Not found'));
+      } else if (this.deviceState === false) {
+        this.log(`Current brightness is 0% because device is off`);
+        callback(null, 0);
       } else {
         const brightness = utils.dimlevelToBrightness(this.dimLevel);
         this.log(`Current dim level ${this.dimLevel} with brightness ${brightness}%`);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,6 +21,25 @@ class Utils {
   }
 
   /**
+   * Convert a percentile brightness level of 1 - 100 to a dim level of 0 - 15
+   * @param brightness
+   * @returns {number}
+   */
+  brightnessToDimlevel(brightness) {
+    return brightness == 0 ? 0 : Math.ceil(brightness / (100 / 16)) - 1;
+  }
+
+  /**
+   * Convert a dim level of 0 - 15 to a percentage of 1 - 100
+   * @param brightness
+   * @returns {number}
+   */
+  dimlevelToBrightness(dimlevel) {
+    // Levels range from 0 - 15, but should be 1 - 16 (0 isn't off, so percentage shouldn't be 0 either)
+    return Math.round((dimlevel + 1) / 16 * 100);
+  }
+
+  /**
    * Returns promise providing JSON of the message.
    * @param message
    * @returns {Promise}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-pilight",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Homebridge plugin connecting to pilight",
   "repository": {
     "type": "git",


### PR DESCRIPTION
First of, thanks for the great Homebridge plugin! Worked great from the start with my regular switches, but didn't support my dimmers in a way that was easy to use. So I decided to make some improvements, you can merge them with your work or just leave them be, that's up to you. 😉 

Besides adding support for the Lightbulb accessory to support brightness changes, I had to make some changes to how incoming messages from the web socket are handled and when callbacks are performed. This was necessary because changing the brightness of a lamp from the Home app in iOS 10 happens as a continuous stream if you immediately invoke the callback. This causes way too many messages being sent to the pilight socket at once which makes the brightness slider jump around a lot.

By putting the callback invocation in the message handling you get real-time status updates for the Home app. (You see a small spinner until the change has actually taken place in pilight.)

I also took the liberty of refactoring the handleMessage method itself so there was no need for the redundant code blocks any more. I don't know why all the setValue calls were there though. For dimmers this caused massive problems, because this would send the ON signal to a KAKU dimmer **twice**, which makes it go in dimming toggle mode which makes the light go from 0 to 100% to 0 continuously. (So I also added some other checks the prevent this from happening.)
